### PR TITLE
Update reference to recent move of repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This repository contains the necessary code to generate the distribution from an
 
 ## Where to download?
 
-You can download the latest release [here](https://github.com/cadriel/FluiddPI/releases/latest).
+You can download the latest release [here](https://github.com/fluidd-core/FluiddPI/releases/latest).
 
-Older releases can be found [here](https://github.com/cadriel/FluiddPI/releases).
+Older releases can be found [here](https://github.com/fluidd-core/FluiddPI/releases).
 
 ## How to use?
 
@@ -60,7 +60,7 @@ git p7zip-full python3 curl
 
 ```bash
 # To build;
-git clone https://github.com/cadriel/FluiddPI.git
+git clone https://github.com/fluidd-core/FluiddPI.git
 cd FluiddPI/
 make build
 ```

--- a/src/README.md
+++ b/src/README.md
@@ -4,7 +4,7 @@ FluiddPI can be built from Debian, Ubuntu, Raspbian, OctoPi, or even FluiddPI. B
 sudo apt-get install gawk util-linux qemu-user-static git p7zip-full python3
 
 git clone https://github.com/guysoft/CustomPiOS.git
-git clone https://github.com/cadriel/FluiddPI.git
+git clone https://github.com/fluidd-core/FluiddPI.git
 cd FluiddPI/src/image
 wget -c --trust-server-names 'https://downloads.raspberrypi.org/raspios_lite_armhf_latest'
 cd ..

--- a/src/modules/fluidd/start_chroot_script
+++ b/src/modules/fluidd/start_chroot_script
@@ -26,7 +26,7 @@ ln -s /etc/nginx/sites-available/fluidd /etc/nginx/sites-enabled/
 cd /home/pi/
 [ ! -d /home/pi/gcode_files ] && su -c "mkdir /home/pi/gcode_files" - pi
 su -c "mkdir /home/pi/fluidd" - pi
-su -c "wget -q -O fluidd.zip https://github.com/cadriel/fluidd/releases/latest/download/fluidd.zip" - pi
+su -c "wget -q -O fluidd.zip https://github.com/fluidd-core/fluidd/releases/latest/download/fluidd.zip" - pi
 su -c "unzip fluidd.zip -d /home/pi/fluidd" - pi
 rm /home/pi/fluidd.zip
 

--- a/src/modules/moonraker/filesystem/home/pi/klipper_config/moonraker.conf
+++ b/src/modules/moonraker/filesystem/home/pi/klipper_config/moonraker.conf
@@ -36,5 +36,5 @@ enable_auto_refresh: True
 # this enabled fluidd updates
 [update_manager client fluidd]
 type: web
-repo: cadriel/fluidd
+repo: fluidd-core/fluidd
 path: ~/fluidd


### PR DESCRIPTION
Moved all references from https://github.com/cadriel to https://github.com/fluidd-core and also updated the Auto Updater reference in moonraker.