### PR TITLE
fix: image build

### DIFF
--- a/.github/workflows/BuildRaspiOS.yml
+++ b/.github/workflows/BuildRaspiOS.yml
@@ -32,8 +32,8 @@ jobs:
           path: repository
           submodules: true
 
-      - name: Download Raspbian Source Image
-        run: aria2c -d repository/src/image/ --seed-time=0 https://downloads.raspberrypi.org/raspios_lite_armhf_latest.torrent
+      - name: Download Raspberry Pi OS Source Image
+        run: aria2c -d repository/src/image/ --seed-time=0 https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-03-25/2021-03-04-raspios-buster-armhf-lite.zip.torrent
       
       - name: Update CustomPiOS Paths
         run: cd repository/src && ../../CustomPiOS/src/update-custompios-paths

--- a/.github/workflows/BuildRaspiOS.yml
+++ b/.github/workflows/BuildRaspiOS.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - '**'
-    tags-ignore: 
+    tags-ignore:
       - '**'
   pull_request:
     types: [ opened, edited ]
@@ -17,14 +17,14 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: sudo apt update; sudo apt install coreutils p7zip-full qemu-user-static zip 
+        run: sudo apt update; sudo apt install coreutils p7zip-full qemu-user-static zip
 
       - name: Checkout CustomPiOS
         uses: actions/checkout@v2
         with:
           repository: 'guysoft/CustomPiOS'
           path: CustomPiOS
-      
+
       - name: Checkout FluiddPI Project
         uses: actions/checkout@v2
         with:
@@ -33,8 +33,8 @@ jobs:
           submodules: true
 
       - name: Download Raspberry Pi OS Source Image
-        run: aria2c -d repository/src/image/ --seed-time=0 https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-03-25/2021-03-04-raspios-buster-armhf-lite.zip.torrent
-      
+        run: aria2c -d repository/src/image/ --seed-time=0 https://downloads.raspberrypi.org/raspios_lite_armhf_latest.torrent
+
       - name: Update CustomPiOS Paths
         run: cd repository/src && ../../CustomPiOS/src/update-custompios-paths
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Copy output image
         run: cp ${{ github.workspace }}/repository/src/workspace/*-raspios-*-lite.img fluiddpi-raspios-lite-latest.img
-      
+
       - name: Compress the image
         run: zip fluiddpi-raspios-lite-latest.zip fluiddpi-raspios-lite-latest.img
 

--- a/.github/workflows/ReleaseRaspiOS.yml
+++ b/.github/workflows/ReleaseRaspiOS.yml
@@ -24,8 +24,8 @@ jobs:
           path: repository
           submodules: true
 
-      - name: Download Raspbian Source Image
-        run: aria2c -d repository/src/image/ --seed-time=0 https://downloads.raspberrypi.org/raspios_lite_armhf_latest.torrent
+      - name: Download Raspberry Pi OS Source Image
+        run: aria2c -d repository/src/image/ --seed-time=0 https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-03-25/2021-03-04-raspios-buster-armhf-lite.zip.torrent
       
       - name: Update CustomPiOS Paths
         run: cd repository/src && ../../CustomPiOS/src/update-custompios-paths

--- a/.github/workflows/ReleaseRaspiOS.yml
+++ b/.github/workflows/ReleaseRaspiOS.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repository: 'guysoft/CustomPiOS'
           path: CustomPiOS
-      
+
       - name: Checkout FluiddPI Project
         uses: actions/checkout@v2
         with:
@@ -25,8 +25,8 @@ jobs:
           submodules: true
 
       - name: Download Raspberry Pi OS Source Image
-        run: aria2c -d repository/src/image/ --seed-time=0 https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-03-25/2021-03-04-raspios-buster-armhf-lite.zip.torrent
-      
+        run: aria2c -d repository/src/image/ --seed-time=0 https://downloads.raspberrypi.org/raspios_lite_armhf_latest.torrent
+
       - name: Update CustomPiOS Paths
         run: cd repository/src && ../../CustomPiOS/src/update-custompios-paths
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Copy output image
         run: cp ${{ github.workspace }}/repository/src/workspace/*-raspios-*-lite.img fluiddpi-raspios-lite-latest.img
-      
+
       - name: Compress the image
         run: zip fluiddpi-raspios-lite-latest.zip fluiddpi-raspios-lite-latest.img
 

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ build: verifyimage
 	docker-compose down
 
 verifyimage:
-	@if [ ! -f "src/image/2021-03-04-raspios-buster-armhf-lite.zip" ]; then echo "Raspberry Pi OS image does not exist. Starting Download..."; curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/2021-03-04-raspios-buster-armhf-lite.zip; else \
-	echo "Raspberry Pi OS image found. Starting checksum verification"; curl -J -L https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha1 > src/image/2021-03-04-raspios-buster-armhf-lite.zip.sha1; \
-	IMAGE_SHA1=`sha1sum src/image/2021-03-04-raspios-buster-armhf-lite.zip | awk '{print $$1}'`; \
-	DL_SHA1=`awk '{print $$1}' src/image/2021-03-04-raspios-buster-armhf-lite.zip.sha1`; \
-	if [ "$$IMAGE_SHA1" != "$$DL_SHA1" ]; then echo "SHAs do not match."; echo "Got $$IMAGE_SHA1"; echo "Expected $$DL_SHA1"; echo "Starting image download"; curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/2021-03-04-raspios-buster-armhf-lite.zip; else echo "SHAs Matched"; fi; fi
+	@if [ ! -f "src/image/raspberry_pi_os-latest.zip" ]; then echo "Raspbian image does not exist. Starting Download..."; curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/raspberry_pi_os.zip; else \
+	echo "Raspberry Pi OS image found. Starting checksum verification"; curl -J -L https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha1 > src/image/raspberry_pi_os-latest.zip.sha1; \
+	IMAGE_SHA1=`sha1sum src/image/raspberry_pi_os-latest.zip | awk '{print $$1}'`; \
+	DL_SHA1=`awk '{print $$1}' src/image/raspberry_pi_os-latest.zip.sha1`; \
+	if [ "$$IMAGE_SHA1" != "$$DL_SHA1" ]; then echo "SHAs do not match."; echo "Got $$IMAGE_SHA1"; echo "Expected $$DL_SHA1"; echo "Starting image download"; curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/raspberry_pi_os-latest.zip; else echo "SHAs Matched"; fi; fi
 
 clean:
 	rm -rf src/workspace
 	rm -f src/build.log
-	rm -f src/image/*.zip.sha1
+	rm -f src/image/raspberry_pi_os-latest.zip.sha1
 
 distclean:
 	rm -rf src/image/*.zip

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ build: verifyimage
 	docker-compose down
 
 verifyimage:
-	@if [ ! -f "src/image/raspbian_latest-raspbian.zip" ]; then echo "Raspbian image does not exist. Starting Download..."; curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/raspbian_latest-raspbian.zip; else \
-	echo "Raspbian image found. Starting checksum verification"; curl -J -L https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha1 > src/image/raspbian_latest-raspbian.zip.sha1; \
-	IMAGE_SHA1=`sha1sum src/image/raspbian_latest-raspbian.zip | awk '{print $$1}'`; \
-	DL_SHA1=`awk '{print $$1}' src/image/raspbian_latest-raspbian.zip.sha1`; \
-	if [ "$$IMAGE_SHA1" != "$$DL_SHA1" ]; then echo "SHAs do not match."; echo "Got $$IMAGE_SHA1"; echo "Expected $$DL_SHA1"; echo "Starting image download"; curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/raspbian_latest-raspbian.zip; else echo "SHAs Matched"; fi; fi
+	@if [ ! -f "src/image/2021-03-04-raspios-buster-armhf-lite.zip" ]; then echo "Raspberry Pi OS image does not exist. Starting Download..."; curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/2021-03-04-raspios-buster-armhf-lite.zip; else \
+	echo "Raspberry Pi OS image found. Starting checksum verification"; curl -J -L https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha1 > src/image/2021-03-04-raspios-buster-armhf-lite.zip.sha1; \
+	IMAGE_SHA1=`sha1sum src/image/2021-03-04-raspios-buster-armhf-lite.zip | awk '{print $$1}'`; \
+	DL_SHA1=`awk '{print $$1}' src/image/2021-03-04-raspios-buster-armhf-lite.zip.sha1`; \
+	if [ "$$IMAGE_SHA1" != "$$DL_SHA1" ]; then echo "SHAs do not match."; echo "Got $$IMAGE_SHA1"; echo "Expected $$DL_SHA1"; echo "Starting image download"; curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/2021-03-04-raspios-buster-armhf-lite.zip; else echo "SHAs Matched"; fi; fi
 
 clean:
 	rm -rf src/workspace
 	rm -f src/build.log
-	rm -f src/image/raspbian_latest-raspbian.zip.sha1
+	rm -f src/image/*.zip.sha1
 
 distclean:
 	rm -rf src/image/*.zip

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A pi image with Klipper, Moonraker and Fluidd pre-installed.
 
-This repository contains the necessary code to generate the distribution from an existing Raspbian lite distro image.
+This repository contains the necessary code to generate the distribution from an existing Raspberry Pi OS lite distro image.
 
 ## Where to download?
 
@@ -44,8 +44,6 @@ Recommended environment is Ubuntu or similar, with docker and docker-compose ins
 - [docker](https://docs.docker.com/engine/install/ubuntu/)
 - [docker-compose](https://docs.docker.com/compose/install/)
 - [qemu-arm-static](http://packages.debian.org/sid/qemu-user-static)
-- [CustomPiOS](https://github.com/guysoft/CustomPiOS)
-- [Downloaded Raspbian Image](http://www.raspbian.org/)
 - QEMU for emulation
 - around ~5gb free space
 
@@ -86,7 +84,7 @@ make distclean
 ```bash
 fluiddpi/
   /emulation - Contains dependencies for emulation testing
-  /src/image - Contains our base raspbian image
+  /src/image - Contains our base Raspberry Pi OS image
   /src/workspace - Created during build, and output for compiled images
 ```
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,5 @@
-Build FluiddPI From within FluiddPI / OctoPi / Raspbian / Debian / Ubuntu
-FluiddPI can be built from Debian, Ubuntu, Raspbian, OctoPi, or even FluiddPI. Build requires about 5 GB of free space available. You can build it by issuing the following commands:
+Build FluiddPI From within FluiddPI / OctoPi / Raspberry Pi OS / Debian / Ubuntu
+FluiddPI can be built from Debian, Ubuntu, Raspberry Pi OS, OctoPi, or even FluiddPI. Build requires about 5 GB of free space available. You can build it by issuing the following commands:
 
 sudo apt-get install gawk util-linux qemu-user-static git p7zip-full python3
 

--- a/src/config
+++ b/src/config
@@ -2,4 +2,4 @@ export DIST_NAME=FluiddPI
 export DIST_VERSION=0.4.0
 export BASE_IMAGE_ENLARGEROOT=2500
 export BASE_IMAGE_RESIZEROOT=500
-export MODULES="base,pkgupgrade(network,raspicam,klipper,moonraker,fluidd,mjpgstreamer,password-for-sudo)"
+export MODULES="base,releaseinfochange(network,raspicam,klipper,moonraker,fluidd,mjpgstreamer,password-for-sudo)"

--- a/src/config
+++ b/src/config
@@ -2,4 +2,4 @@ export DIST_NAME=FluiddPI
 export DIST_VERSION=0.4.0
 export BASE_IMAGE_ENLARGEROOT=2500
 export BASE_IMAGE_RESIZEROOT=500
-export MODULES="base(network,raspicam,klipper,moonraker,fluidd,mjpgstreamer,password-for-sudo)"
+export MODULES="base,pkgupgrade(network,raspicam,klipper,moonraker,fluidd,mjpgstreamer,password-for-sudo)"

--- a/src/image/README
+++ b/src/image/README
@@ -1,5 +1,5 @@
 Place zipped Rasbian image here.
 
 If not otherwise specified, the build script will always use the most
-recent zip file matching the file name pattern "*-raspbian.zip" located
+recent zip file matching the file name pattern "*.zip" located
 here.

--- a/src/modules/klipper/config
+++ b/src/modules/klipper/config
@@ -1,5 +1,5 @@
 [ -n "$KLIPPER_SRC_DIR" ] || KLIPPER_SRC_DIR=/home/pi/klipper
 [ -n "$KLIPPER_PYTHON_DIR" ] || KLIPPER_PYTHON_DIR=/home/pi/klippy-env
 
-[ -n "$KLIPPER_REPO_SHIP" ] || KLIPPER_REPO_SHIP=https://github.com/KevinOConnor/klipper.git
+[ -n "$KLIPPER_REPO_SHIP" ] || KLIPPER_REPO_SHIP=https://github.com/Klipper3d/klipper.git
 [ -n "$KLIPPER_REPO_BRANCH" ] || KLIPPER_REPO_BRANCH=master

--- a/src/modules/klipper/start_chroot_script
+++ b/src/modules/klipper/start_chroot_script
@@ -33,7 +33,7 @@ apt install libusb-dev -y
 # AVR chip installation and building
 apt install avrdude gcc-avr binutils-avr avr-libc -y
 apt install stm32flash dfu-util libnewlib-arm-none-eabi -y
-apt install gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0 -y
+apt install gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0-0 -y
 
 #Make sure user pi has access to serial ports
 usermod -a -G tty pi

--- a/src/modules/klipper/start_chroot_script
+++ b/src/modules/klipper/start_chroot_script
@@ -22,7 +22,7 @@ apt update
 apt install wget git gpiod -y
 
 # Packages for python cffi
-apt install python-virtualenv virtualenv python-dev libffi-dev build-essential -y
+apt install virtualenv python-dev libffi-dev build-essential -y
 
 # kconfig requirements
 apt install libncurses-dev -y

--- a/src/modules/mjpgstreamer/start_chroot_script
+++ b/src/modules/mjpgstreamer/start_chroot_script
@@ -16,7 +16,7 @@ install_cleanup_trap
 unpack /filesystem/home/pi /home/pi pi
 
 apt update
-apt install -y --allow-downgrades git cmake=3.13.4-1 cmake-data=3.13.4-1
+apt install -y --allow-downgrades git cmake cmake-data
 cd /home/pi
   #mjpg-streamer
   if [ "$MJPGSTREAMER_INCLUDE_MJPGSTREAMER" == "yes" ]
@@ -24,10 +24,10 @@ cd /home/pi
     echo "--- Installing mjpg-streamer"
     if [ $( is_in_apt libjpeg62-turbo-dev ) -eq 1 ]; then
       apt-get -y --force-yes install libjpeg62-turbo-dev
-    elif [ $( is_in_apt libjpeg8-dev ) -eq 1 ]; then 
+    elif [ $( is_in_apt libjpeg8-dev ) -eq 1 ]; then
       apt-get -y --force-yes install libjpeg8-dev
     fi
-    
+
     apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages --no-install-recommends install imagemagick ffmpeg libv4l-dev
     gitclone MJPGSTREAMER_MJPGSTREAMER_REPO mjpg-streamer
     pushd mjpg-streamer

--- a/src/modules/releaseinfochange/start_chroot_script
+++ b/src/modules/releaseinfochange/start_chroot_script
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -xe
+
+source /common.sh
+install_cleanup_trap
+
+apt update --allow-releaseinfo-change
+apt full-upgrade --yes


### PR DESCRIPTION
Updates to Raspberry Pi OS

Removes `python-virtualenv` dependency as per https://github.com/Klipper3d/klipper/commit/dd7b98cce43056c1a5a99204909ecaa49451aa22

Build is passing now, no idea if this is actually working or not...

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>