### PR TITLE
chore: adjust update manager refresh interval

### DIFF
--- a/src/modules/moonraker/filesystem/home/pi/klipper_config/moonraker.conf
+++ b/src/modules/moonraker/filesystem/home/pi/klipper_config/moonraker.conf
@@ -32,6 +32,7 @@ trusted_clients:
 # this enables moonraker's update manager
 [update_manager]
 enable_auto_refresh: True
+refresh_interval: 24
 
 # this enabled fluidd updates
 [update_manager client fluidd]


### PR DESCRIPTION
Moonraker's new default is set to 28 days, making these automatic updates fairly pointless for a lot of users (they just manually check for updates). This PR sets the default interval to 24h.