### PR TITLE
fix: temporarily disable IPv6

### DIFF
--- a/src/modules/fluidd/filesystem/root/etc/nginx/sites-available/fluidd
+++ b/src/modules/fluidd/filesystem/root/etc/nginx/sites-available/fluidd
@@ -1,6 +1,5 @@
 server {
     listen 80 default_server;
-    listen [::]:80 default_server;
 
     access_log /var/log/nginx/fluidd-access.log;
     error_log /var/log/nginx/fluidd-error.log;


### PR DESCRIPTION
Temporarily turns off IPv6 until we can find a better solution to adding the v6 subnet to authorized_hosts. Not ideal, but we don't have another solution yet.