### PR TITLE
Escape echo quotation marks with backslashes in runMjpgStreamer()

### DIFF
--- a/src/modules/mjpgstreamer/filesystem/root/usr/local/bin/webcamd
+++ b/src/modules/mjpgstreamer/filesystem/root/usr/local/bin/webcamd
@@ -147,7 +147,7 @@ function runMjpgStreamer {
     fi
 
     pushd $MJPGSTREAMER_HOME > /dev/null 2>&1
-        echo Running ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" -i "$input"
+        echo Running ./mjpg_streamer -o \"output_http.so -w $camera_http_webroot $camera_http_options\" -i \"$input\"
         LD_LIBRARY_PATH=. ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" -i "$input" &
         sleep 1 &
         sleep_pid=$!


### PR DESCRIPTION
This commit don't change the behavior of runMjpgStreamer().
It purse is only to echo "Running ./mjpg_streamer..." same as it is executed.

_Originally posted by @Avedena in https://github.com/fluidd-core/FluiddPI/issues/36#issuecomment-1186511027_