### PR TITLE
Improve support for armbian based images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 src/config.local
 src/custompios_path
-src/image/*.zip
-src/image-variants/*.zip
+src/image
+src/image-*
+!src/image/README
 **/key.json
 src/nightly_build_scripts/index.html
 src/nightly_build_scripts/node_modules

--- a/src/config
+++ b/src/config
@@ -2,4 +2,4 @@ export DIST_NAME=FluiddPI
 export DIST_VERSION=0.4.0
 export BASE_IMAGE_ENLARGEROOT=2500
 export BASE_IMAGE_RESIZEROOT=500
-export MODULES="base,releaseinfochange(network,raspicam,klipper,moonraker,fluidd,mjpgstreamer,password-for-sudo)"
+export MODULES="base,pkgupgrade(network,raspicam,klipper,moonraker,fluidd,mjpgstreamer,password-for-sudo)"

--- a/src/modules/moonraker/end_chroot_script
+++ b/src/modules/moonraker/end_chroot_script
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+
+rm -rf /etc/sudoers.d/pi-moonraker-install

--- a/src/modules/moonraker/start_chroot_script
+++ b/src/modules/moonraker/start_chroot_script
@@ -17,6 +17,11 @@ install_cleanup_trap
 unpack /filesystem/home/pi /home/pi pi
 unpack /filesystem/root /
 
+if [ -f /etc/armbian-release ]; then
+  echo "pi ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/pi-moonraker-install
+  chmod 0440 /etc/sudoers.d/pi-moonraker-install
+fi
+
 echo "Installing Moonraker"
 
 apt update

--- a/src/modules/releaseinfochange/start_chroot_script
+++ b/src/modules/releaseinfochange/start_chroot_script
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -xe
-
-source /common.sh
-install_cleanup_trap
-
-apt update --allow-releaseinfo-change
-apt full-upgrade --yes


### PR DESCRIPTION
Improve/fix the building of FluiddPi images based off Armbian

- Use pkgupgrade module from CustomPiOS instead of releaseinfochange
  releaseinfochange module isn't handling changes to configuration files well,
  prompting for user input during the build process. The CustomPiOS module
  pkgupgrade provides the same functionality and handles user input requests
  better.
- Fix Moonraker install
  The Moonraker sudo\_fix.sh script is broken when the user doesn't have
  password-less sudo enabled. Ensure that the pi user can sudo without
  prompting for a password for the duration of the build process.
- Rework .gitignore to ignore armbian build images
  Building variants uses different image and workspace directories, cover
  these in the .gitignore rules.
