### PR TITLE
docs: correct README.md formatting

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,11 @@
-Build FluiddPI From within FluiddPI / OctoPi / Raspberry Pi OS / Debian / Ubuntu
+# FluidPI src
+
+Build FluiddPI From within FluiddPI / OctoPi / Raspberry Pi OS / Debian / Ubuntu.
+
+## Build
 FluiddPI can be built from Debian, Ubuntu, Raspberry Pi OS, OctoPi, or even FluiddPI. Build requires about 5 GB of free space available. You can build it by issuing the following commands:
 
+```bash
 sudo apt-get install gawk util-linux qemu-user-static git p7zip-full python3
 
 git clone https://github.com/guysoft/CustomPiOS.git
@@ -11,3 +16,4 @@ cd ..
 ../../CustomPiOS/src/update-custompios-paths
 sudo modprobe loop
 sudo bash -x ./build_dist
+```

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # FluiddPI source
 
-Build FluiddPI From within FluiddPI / OctoPi / Raspberry Pi OS / Debian / Ubuntu.
+Build FluiddPI from within FluiddPI / OctoPi / Raspberry Pi OS / Debian / Ubuntu.
 
 ## Build
 FluiddPI can be built from Debian, Ubuntu, Raspberry Pi OS, OctoPi, or even FluiddPI. Build requires about 5 GB of free space available. You can build it by issuing the following commands:

--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,4 @@
-# FluidPI src
+# FluiddPI source
 
 Build FluiddPI From within FluiddPI / OctoPi / Raspberry Pi OS / Debian / Ubuntu.
 


### PR DESCRIPTION
The README.md was missing any sort of markdown formatting, and was thus rendering as several continuous strings of commands without punctuation.