### PR TITLE
fix: fix support for Raspberry Pi Camera Module v2.1

### DIFF
--- a/src/modules/mjpgstreamer/filesystem/root/usr/local/bin/webcamd
+++ b/src/modules/mjpgstreamer/filesystem/root/usr/local/bin/webcamd
@@ -216,7 +216,7 @@ while true; do
   video_devices=($(find /dev -regextype sed -regex '\/dev/video[0-9]\+' | sort -nk1.11 2> /dev/null))
 
   # add list of raspi camera into an array
-  if [ "`vcgencmd get_camera`" = "supported=1 detected=1" ]; then
+  if [[ "`vcgencmd get_camera`" = "supported=1 detected=1"* ]]; then
     video_devices+=( "raspi" )
   fi
 


### PR DESCRIPTION
Encountered some issues on a fresh fluiddpi install where a brand new RaspberryPi Camera module would not work properly, labelled as "Camera Module v2.1".

After trying an `rpi-update` and an `apt-get update; apt-get upgrade` with no luck

I finally did pinpoint the issue to this test in the `webcamd` service:

```
if [ "`vcgencmd get_camera`" = "supported=1 detected=1" ]; then
```

that would fail on my pi since the output of `vcgencmd get_camera` is actually:

```
supported=1 detected=1, libcamera interfaces=0
```